### PR TITLE
feat: add deno permission args

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ flags or configuration has been set.
 
 ``` 
 Usage:
-    denon [options] [script] [-- <your_args>]
+    denon [OPTIONS] [PERMISSIONS] [SCRIPT] [-- <SCRIPT_ARGS>]
 
-Options:
+OPTIONS:
     -c, --config <file>     A path to a config file, defaults to [default: .denonrc | .denonrc.json]
     -d, --debug             Debugging mode for more verbose logging
     -e, --extensions        List of extensions to look for separated by commas
@@ -29,6 +29,8 @@ Options:
     -q, --quiet             Turns off all logging
     -s, --skip <glob>       Glob pattern for ignoring specific files or directories
     -w, --watch             List of paths to watch separated by commas
+
+PERMISSIONS: All deno permission options to run SCRIPT (--allow-*)
 ```
 
 ## Configuration
@@ -59,6 +61,10 @@ Example configuration with all of the possible configuration values set to somet
     "watch": [
         "source/",
         "tools/"
+    ],
+    "permissions":[
+        "net",
+        "read"
     ],
     "execute": {
         ".js": ["deno", "run"],

--- a/denon_test.ts
+++ b/denon_test.ts
@@ -1,0 +1,49 @@
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+
+import { parseArgs } from "./denon.ts";
+
+Deno.test(function parseArgsEmpty() {
+    assertEquals(parseArgs([]), {
+        config: undefined,
+        debug: false,
+        extensions: undefined,
+        files: [],
+        fullscreen: false,
+        help: false,
+        interval: undefined,
+        match: undefined,
+        permissions: [],
+        quiet: false,
+        runnerFlags: [],
+        skip: undefined,
+        watch: undefined
+    });
+});
+
+Deno.test(function parseArgsAll() {
+    assertEquals(
+        parseArgs([
+            ..."--config denon.json -dfqhe js,ts -i 500 -m foo/** -s bar/**".split(
+                " "
+            ),
+            ..."-w lib/** --allow-run mod.ts -- --allow-net --port 500".split(
+                " "
+            )
+        ]),
+        {
+            config: "denon.json",
+            debug: true,
+            extensions: "js,ts",
+            files: ["mod.ts"],
+            fullscreen: true,
+            help: true,
+            interval: "500",
+            match: "foo/**",
+            permissions: ["--allow-run"],
+            quiet: true,
+            runnerFlags: ["--allow-net", "--port", "500"],
+            skip: "bar/**",
+            watch: "lib/**"
+        }
+    );
+});

--- a/denonrc.ts
+++ b/denonrc.ts
@@ -11,6 +11,7 @@ export interface DenonConfig {
     skip: string[] | undefined;
     interval: number;
     watch: string[];
+    permissions: string[];
     execute: { [extension: string]: string[] };
 }
 
@@ -24,6 +25,7 @@ export const DenonConfigDefaults: DenonConfig = {
     skip: undefined,
     interval: 500,
     watch: [],
+    permissions: [],
     execute: {
         ".js": ["deno", "run"],
         ".ts": ["deno", "run"]
@@ -45,10 +47,16 @@ export async function readConfig(file?: string): Promise<DenonConfig> {
         }
     }
 
-    let json = {};
+    let json = {} as any;
 
     if (file) {
         json = JSON.parse(await readFileStr(file));
+    }
+
+    if (json.permissions) {
+        json.permissions = json.permissions.map((p: string) =>
+            p.startsWith("--allow-") ? p : `--allow-${p}`
+        );
     }
 
     return { ...DenonConfigDefaults, ...json };


### PR DESCRIPTION
solves

```
denon --allow-net server.ts
[DENON] Could not start denon because no file was provided, use -h for help
```

ATM it is not possible to pass arguments to Deno without creating a config file