### PR TITLE
Bugfix

### DIFF
--- a/denon.ts
+++ b/denon.ts
@@ -224,7 +224,7 @@ if (import.meta.main) {
 
             debug(`Running "${args.join(" ")}"`);
             proc = Deno.run({
-                cmd: args
+                args
             });
         };
     };


### PR DESCRIPTION
Hello, trying to install denon I see that error:

> error TS2345: Argument of type '{ cmd: string[]; }' is not assignable to parameter of type 'RunOptions'.
>   Object literal may only specify known properties, and 'cmd' does not exist in type 'RunOptions'.
> 
> ► https://deno.land/x/denon/denon.ts:227:17
> 
> 227                 cmd: args

The problem was with the Deno.run interface on install, cmd has removed and now its only args.

Just a litle change.