### PR TITLE
pass all unknown args to deno run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ flags or configuration has been set.
 
 ``` 
 Usage:
-    denon [OPTIONS] [PERMISSIONS] [SCRIPT] [-- <SCRIPT_ARGS>]
+    denon [OPTIONS] [DENO_ARGS] [SCRIPT] [-- <SCRIPT_ARGS>]
 
 OPTIONS:
     -c, --config <file>     A path to a config file, defaults to [default: .denonrc | .denonrc.json]
@@ -30,7 +30,7 @@ OPTIONS:
     -s, --skip <glob>       Glob pattern for ignoring specific files or directories
     -w, --watch             List of paths to watch separated by commas
 
-PERMISSIONS: All deno permission options to run SCRIPT (--allow-*)
+DENO_ARGS: Arguments passed to Deno to run SCRIPT (like permisssions)
 ```
 
 ## Configuration
@@ -62,9 +62,9 @@ Example configuration with all of the possible configuration values set to somet
         "source/",
         "tools/"
     ],
-    "permissions":[
-        "net",
-        "read"
+    "deno_args":[
+        "--allow-net",
+        "--import-map=import-map.json"
     ],
     "execute": {
         ".js": ["deno", "run"],

--- a/README.md
+++ b/README.md
@@ -90,4 +90,3 @@ Contributions are very welcome! Just remember to run `deno fmt` to keep the styl
 -   [ ] Fix match and skip globs [#10](https://github.com/eliassjogreen/denon/issues/10)
 -   [ ] Tests
 -   [ ] Use [deno fs evens](https://deno.land/std/manual.md) instead of the current watcher
--   [ ] Use [denomander](https://github.com/siokas/denomander)

--- a/denon.ts
+++ b/denon.ts
@@ -1,12 +1,12 @@
-import { parse } from "https://raw.githubusercontent.com/ronhippler/deno/master/std/flags/mod.ts";
-import { exists } from "https://deno.land/std/fs/mod.ts";
 import {
   dirname,
-  resolve,
+  exists,
+  extname,
   globToRegExp,
-  extname
-} from "https://deno.land/std/path/mod.ts";
-import { MuxAsyncIterator } from "https://deno.land/std/util/async.ts";
+  MuxAsyncIterator,
+  parse,
+  resolve,
+} from "./deps.ts";
 import { DenonConfig, DenonConfigDefaults, readConfig } from "./denonrc.ts";
 import { debug, log, fail, setConfig } from "./log.ts";
 import { watch, FileEvent, FileChange } from "./watcher.ts";

--- a/denon_test.ts
+++ b/denon_test.ts
@@ -1,49 +1,103 @@
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
-import { parseArgs } from "./denon.ts";
+import { parseArgs, Args } from "./denon.ts";
 
 Deno.test(function parseArgsEmpty() {
-  assertEquals(parseArgs([]), {
-    config: undefined,
-    debug: false,
-    extensions: undefined,
-    files: [],
-    fullscreen: false,
-    help: false,
-    interval: undefined,
-    match: undefined,
-    permissions: [],
-    quiet: false,
-    runnerFlags: [],
-    skip: undefined,
-    watch: undefined,
-  });
+    const expected: Args = {
+        config: undefined,
+        debug: false,
+        deno_args: [],
+        extensions: undefined,
+        files: [],
+        fullscreen: false,
+        help: false,
+        interval: undefined,
+        match: undefined,
+        quiet: false,
+        runnerFlags: [],
+        skip: undefined,
+        watch: undefined
+    };
+    assertEquals(parseArgs([]), expected);
+});
+
+Deno.test(function parseArgsOnlyFile() {
+    let args = ["mod.ts"]
+    const expected: Args = {
+        config: undefined,
+        debug: false,
+        deno_args: [],
+        extensions: undefined,
+        files: ["mod.ts"],
+        fullscreen: false,
+        help: false,
+        interval: undefined,
+        match: undefined,
+        quiet: false,
+        runnerFlags: [],
+        skip: undefined,
+        watch: undefined
+    };
+    assertEquals(parseArgs(args), expected);
+});
+
+Deno.test(function parseArgsWithoutFile() {
+    let args = ["--config", "config.json"]
+    const expected: Args = {
+        config: "config.json",
+        debug: false,
+        deno_args: [],
+        extensions: undefined,
+        files: [],
+        fullscreen: false,
+        help: false,
+        interval: undefined,
+        match: undefined,
+        quiet: false,
+        runnerFlags: [],
+        skip: undefined,
+        watch: undefined
+    };
+    assertEquals(parseArgs(args), expected);
+});
+
+Deno.test(function parseArgsDoubleDashWithoutFile() {
+    let args = "-A -c config.json -- --foo bar".split(" ");
+    const expected: Args = {
+        config: "config.json",
+        debug: false,
+        deno_args: ["-A"],
+        extensions: undefined,
+        files: [],
+        fullscreen: false,
+        help: false,
+        interval: undefined,
+        match: undefined,
+        quiet: false,
+        runnerFlags: ["--foo", "bar"],
+        skip: undefined,
+        watch: undefined
+    };
+    assertEquals(parseArgs(args), expected);
 });
 
 Deno.test(function parseArgsAll() {
-  assertEquals(
-    parseArgs([
-      ..."--config denon.json -dfqhe js,ts -i 500 -m foo/** -s bar/**".split(
-        " ",
-      ),
-      ..."-w lib/** --allow-run mod.ts -- --allow-net --port 500".split(
-        " ",
-      ),
-    ]),
-    {
-      config: "denon.json",
-      debug: true,
-      extensions: "js,ts",
-      files: ["mod.ts"],
-      fullscreen: true,
-      help: true,
-      interval: "500",
-      match: "foo/**",
-      permissions: ["--allow-run"],
-      quiet: true,
-      runnerFlags: ["--allow-net", "--port", "500"],
-      skip: "bar/**",
-      watch: "lib/**",
-    },
-  );
+    let args = "--config denon.json -dfqhe js,ts -i 500 -m foo/** -s bar/**".split(" ")
+    args = args.concat("-w lib/** --importmap=import_map.json -A mod.ts -- --allow-net --port 500".split(" "))
+    const expected: Args = {
+        config: "denon.json",
+        debug: true,
+        deno_args: ["--importmap=import_map.json", "-A"],
+        extensions: "js,ts",
+        files: ["mod.ts"],
+        fullscreen: true,
+        help: true,
+        interval: "500",
+        match: "foo/**",
+        quiet: true,
+        runnerFlags: ["--allow-net", "--port", "500"],
+        skip: "bar/**",
+        watch: "lib/**"
+    };
+    assertEquals(parseArgs(args), expected);
 });

--- a/denon_test.ts
+++ b/denon_test.ts
@@ -1,103 +1,107 @@
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { test, assertEquals } from "./test_deps.ts";
 
 import { parseArgs, Args } from "./denon.ts";
 
-Deno.test(function parseArgsEmpty() {
-    const expected: Args = {
-        config: undefined,
-        debug: false,
-        deno_args: [],
-        extensions: undefined,
-        files: [],
-        fullscreen: false,
-        help: false,
-        interval: undefined,
-        match: undefined,
-        quiet: false,
-        runnerFlags: [],
-        skip: undefined,
-        watch: undefined
-    };
-    assertEquals(parseArgs([]), expected);
+test(function parseArgsEmpty() {
+  const expected: Args = {
+    config: undefined,
+    debug: false,
+    deno_args: [],
+    extensions: undefined,
+    files: [],
+    fullscreen: false,
+    help: false,
+    interval: undefined,
+    match: undefined,
+    quiet: false,
+    runnerFlags: [],
+    skip: undefined,
+    watch: undefined,
+  };
+  assertEquals(parseArgs([]), expected);
 });
 
-Deno.test(function parseArgsOnlyFile() {
-    let args = ["mod.ts"]
-    const expected: Args = {
-        config: undefined,
-        debug: false,
-        deno_args: [],
-        extensions: undefined,
-        files: ["mod.ts"],
-        fullscreen: false,
-        help: false,
-        interval: undefined,
-        match: undefined,
-        quiet: false,
-        runnerFlags: [],
-        skip: undefined,
-        watch: undefined
-    };
-    assertEquals(parseArgs(args), expected);
+test(function parseArgsOnlyFile() {
+  let args = ["mod.ts"];
+  const expected: Args = {
+    config: undefined,
+    debug: false,
+    deno_args: [],
+    extensions: undefined,
+    files: ["mod.ts"],
+    fullscreen: false,
+    help: false,
+    interval: undefined,
+    match: undefined,
+    quiet: false,
+    runnerFlags: [],
+    skip: undefined,
+    watch: undefined,
+  };
+  assertEquals(parseArgs(args), expected);
 });
 
-Deno.test(function parseArgsWithoutFile() {
-    let args = ["--config", "config.json"]
-    const expected: Args = {
-        config: "config.json",
-        debug: false,
-        deno_args: [],
-        extensions: undefined,
-        files: [],
-        fullscreen: false,
-        help: false,
-        interval: undefined,
-        match: undefined,
-        quiet: false,
-        runnerFlags: [],
-        skip: undefined,
-        watch: undefined
-    };
-    assertEquals(parseArgs(args), expected);
+test(function parseArgsWithoutFile() {
+  let args = ["--config", "config.json"];
+  const expected: Args = {
+    config: "config.json",
+    debug: false,
+    deno_args: [],
+    extensions: undefined,
+    files: [],
+    fullscreen: false,
+    help: false,
+    interval: undefined,
+    match: undefined,
+    quiet: false,
+    runnerFlags: [],
+    skip: undefined,
+    watch: undefined,
+  };
+  assertEquals(parseArgs(args), expected);
 });
 
-Deno.test(function parseArgsDoubleDashWithoutFile() {
-    let args = "-A -c config.json -- --foo bar".split(" ");
-    const expected: Args = {
-        config: "config.json",
-        debug: false,
-        deno_args: ["-A"],
-        extensions: undefined,
-        files: [],
-        fullscreen: false,
-        help: false,
-        interval: undefined,
-        match: undefined,
-        quiet: false,
-        runnerFlags: ["--foo", "bar"],
-        skip: undefined,
-        watch: undefined
-    };
-    assertEquals(parseArgs(args), expected);
+test(function parseArgsDoubleDashWithoutFile() {
+  let args = "-A -c config.json -- --foo bar".split(" ");
+  const expected: Args = {
+    config: "config.json",
+    debug: false,
+    deno_args: ["-A"],
+    extensions: undefined,
+    files: [],
+    fullscreen: false,
+    help: false,
+    interval: undefined,
+    match: undefined,
+    quiet: false,
+    runnerFlags: ["--foo", "bar"],
+    skip: undefined,
+    watch: undefined,
+  };
+  assertEquals(parseArgs(args), expected);
 });
 
-Deno.test(function parseArgsAll() {
-    let args = "--config denon.json -dfqhe js,ts -i 500 -m foo/** -s bar/**".split(" ")
-    args = args.concat("-w lib/** --importmap=import_map.json -A mod.ts -- --allow-net --port 500".split(" "))
-    const expected: Args = {
-        config: "denon.json",
-        debug: true,
-        deno_args: ["--importmap=import_map.json", "-A"],
-        extensions: "js,ts",
-        files: ["mod.ts"],
-        fullscreen: true,
-        help: true,
-        interval: "500",
-        match: "foo/**",
-        quiet: true,
-        runnerFlags: ["--allow-net", "--port", "500"],
-        skip: "bar/**",
-        watch: "lib/**"
-    };
-    assertEquals(parseArgs(args), expected);
+test(function parseArgsAll() {
+  let args = "--config denon.json -dfqhe js,ts -i 500 -m foo/** -s bar/**"
+    .split(" ");
+  args = args.concat(
+    "-w lib/** --importmap=import_map.json -A mod.ts -- --allow-net --port 500"
+      .split(" "),
+  );
+  const expected: Args = {
+    config: "denon.json",
+    debug: true,
+    deno_args: ["--importmap=import_map.json", "-A"],
+    extensions: "js,ts",
+    files: ["mod.ts"],
+    fullscreen: true,
+    help: true,
+    interval: "500",
+    match: "foo/**",
+    quiet: true,
+    runnerFlags: ["--allow-net", "--port", "500"],
+    skip: "bar/**",
+    watch: "lib/**",
+  };
+  assertEquals(parseArgs(args), expected);
 });

--- a/denonrc.ts
+++ b/denonrc.ts
@@ -1,4 +1,4 @@
-import { exists, readFileStr } from "https://deno.land/std/fs/mod.ts";
+import { exists, readFileStr } from "./deps.ts";
 import { fail, debug } from "./log.ts";
 
 export interface DenonConfig {

--- a/denonrc.ts
+++ b/denonrc.ts
@@ -11,7 +11,7 @@ export interface DenonConfig {
   skip: string[] | undefined;
   interval: number;
   watch: string[];
-  permissions: string[];
+  deno_args: string[];
   execute: { [extension: string]: string[] };
 }
 
@@ -25,7 +25,7 @@ export const DenonConfigDefaults: DenonConfig = {
   skip: undefined,
   interval: 500,
   watch: [],
-  permissions: [],
+  deno_args: [],
   execute: {
     ".js": ["deno", "run"],
     ".ts": ["deno", "run"],
@@ -51,12 +51,6 @@ export async function readConfig(file?: string): Promise<DenonConfig> {
 
   if (file) {
     json = JSON.parse(await readFileStr(file));
-  }
-
-  if (json.permissions) {
-    json.permissions = json.permissions.map((p: string) =>
-      p.startsWith("--allow-") ? p : `--allow-${p}`
-    );
   }
 
   return { ...DenonConfigDefaults, ...json };

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,19 @@
+export { parse } from "https://deno.land/std@v0.40.0/flags/mod.ts";
+export {
+  exists,
+  readFileStr,
+  walk,
+} from "https://deno.land/std@v0.40.0/fs/mod.ts";
+export {
+  dirname,
+  resolve,
+  globToRegExp,
+  extname,
+} from "https://deno.land/std@v0.40.0/path/mod.ts";
+export { MuxAsyncIterator } from "https://deno.land/std@v0.40.0/util/async.ts";
+export {
+  yellow,
+  green,
+  red,
+  setColorEnabled,
+} from "https://deno.land/std@v0.40.0/fmt/mod.ts";

--- a/log.ts
+++ b/log.ts
@@ -2,8 +2,8 @@ import {
   yellow,
   green,
   red,
-  setColorEnabled
-} from "https://deno.land/std/fmt/mod.ts";
+  setColorEnabled,
+} from "./deps.ts";
 import { DenonConfig } from "./denonrc.ts";
 
 setColorEnabled(true);

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,0 +1,3 @@
+export const test = Deno.test;
+
+export { assertEquals } from "https://deno.land/std@v0.40.0/testing/asserts.ts";

--- a/watcher.ts
+++ b/watcher.ts
@@ -1,4 +1,4 @@
-import { walk } from "https://deno.land/std/fs/mod.ts";
+import { walk } from "./deps.ts";
 
 /** All of the types of changes that a file can have */
 export enum FileEvent {


### PR DESCRIPTION
now its possible to pass all unknown args to deno run (eg. -A or --importmap).

This would not be possible with denomander.
Thats why i removed the todo.