### PR TITLE
Fix install command for v1.0.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Denon provides most of the features you would expect of a file watcher and more.
 
 To install denon simply enter the following into a terminal:
 
-`deno install denon --unstable --allow-read --allow-run -f https://deno.land/x/denon/denon.ts`
+`deno install --unstable --allow-read --allow-run -f https://deno.land/x/denon/denon.ts`
 
 ## Usage
 


### PR DESCRIPTION
From the release notes, deno install was changed to no longer use a positional argument for setting the name. With the old install command it would just log "Cannot resolve module ./denon".

https://github.com/denoland/deno/blob/master/Releases.md
https://github.com/denoland/deno/pull/5036