### PR TITLE
CLI arguments priority

### DIFF
--- a/denon.ts
+++ b/denon.ts
@@ -49,8 +49,8 @@ if (import.meta.main) {
   }
 
   applyIfDefined(
-    config,
     flags,
+    config,
     [
       "deno_args",
       "extensions",
@@ -71,7 +71,7 @@ if (import.meta.main) {
     const cwd = Deno.cwd();
     debug(`Added watcher for "${cwd}" because of fmt or test config`);
     config.watch.push(cwd);
-  } else if (config.files.length < 1 && flags.files.length < 1) {
+  } else if (flags.files.length < 1) {
     fail(
       "Could not start denon because no file was provided, use -h for help",
     );
@@ -167,7 +167,7 @@ if (import.meta.main) {
 
       const executor = execute(
         ...cmds,
-        ...(binary === "deno" ? flags.deno_args : []),
+        ...(binary === "deno" ? config.deno_args : []),
         file,
         ...flags.runnerFlags,
       );


### PR DESCRIPTION
After using Deno from code, using [this PR](https://github.com/eliassjogreen/denon/pull/36) for [deno_scripts](https://github.com/PabloSzx/deno_scripts) I encountered this bug, and it makes a lot of arguments technically useless.

One solution is changing the `applyIfDefined` order, and making `config` the source of truth, but giving priority to arguments options.

![image](https://user-images.githubusercontent.com/8672915/82112991-5fc95880-9720-11ea-9d72-a8cede09aa1c.png)



fixes #32